### PR TITLE
Fix for outlook login

### DIFF
--- a/services/passport.js
+++ b/services/passport.js
@@ -47,10 +47,9 @@ let outlookStrategy = new OutlookStrategy(
     clientID : authKeys.outlookClientID,
     clientSecret : authKeys.outlookClientSecret,
     proxy : true,
-    callbackURL : `https://www.skedge-api.com/auth/outlook/calback`
+    callbackURL : `${authKeys.domain}/auth/outlook/callback`
   },
   async (accessToken, refreshToken, profile, done) => {
-    console.log("HERE???")
     const existingUser = await User.findOne({ outlookId: profile.id})
     if (existingUser) {
       existingUser.accessToken = accessToken;


### PR DESCRIPTION
In `services/passport.js`:
- Reverted outlookStrategy `callbackURL` to use config variable and fixed typo on line 50
- Removed `console.log()` on line 53
- Consider using http instead of https for config variable `domain` in the development environment

In Microsoft App Registration:
- Make sure all necessary Microsoft Graph Permissions are selected (openid, profile, offline_access, User.Read)
- Consider using http instead of https for redirect URL in the development environment